### PR TITLE
Add user to synology in script.

### DIFF
--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -107,13 +107,21 @@ setuid notifiarr
 exec /usr/bin/notifiarr -c /etc/notifiarr/notifiarr.conf
 EOT
 
-id notifiarr >/dev/null 2>&1
+ID=$(id notifiarr 2>&1)
 if [ "$?" = "0" ]; then
-  echo "${P} Starting service: start notifiarr"
-  start notifiarr
+  echo "${P} Adding notifiarr user: synouser --add notifiarr Notifiarr 0 support@notifiarr.com 0"
+  pass="${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+  synouser --add notifiarr "${pass}" Notifiarr 0 support@notifiarr.com 0
+  #        --add username  pwd       full-name expired{0|1} mail privilege(0=none)
 else
-  echo "${P} IMPORTANT: Add user 'notifiarr' in the GUI!"
+  echo "${P} User notifiarr already exists: ${ID}"
 fi
+
+echo "${P} Restarting service: status notifiarr ; stop notifiarr ; start notifiarr"
+status notifiarr
+["$?" != "0"] || stop notifiarr
+start notifiarr
+
 
 echo "${P} Installed. Edit your config file: /etc/notifiarr/notifiarr.conf"
 echo "${P} The config may be symlinked at:   /volume1/data/notifiarr.conf"


### PR DESCRIPTION
This needs to be tested. This script should be safe to re-run over and over. It will just update the binary and init file. Closes #39.

To test this from this branch/PR:
```bash
#   curl -sL https://raw.githubusercontent.com/Go-Lift-TV/notifiarr/dn2_syno_adduser/scripts/install-synology.sh | sudo bash
```
---
Delete the existing notifiarr user to make sure the script correctly adds the new one. You can also delete the shudders entry and init file for a full test. Run it again to make sure it doesn't have any weird errors on a second pass.
