### PR TITLE
Print debug payloads from 1 place.

### DIFF
--- a/pkg/client/plexsnaps.go
+++ b/pkg/client/plexsnaps.go
@@ -45,7 +45,7 @@ func (c *Client) collectSessions(v *plex.Webhook) {
 	c.Printf("Plex Incoming Webhook: %s, %s '%s' => %s (collecting sessions)",
 		v.Server.Title, v.Account.Title, v.Event, v.Metadata.Title)
 
-	posted, reply, err := c.notify.SendMeta(notifiarr.PlexHook, c.notify.URL, v, plex.WaitTime)
+	reply, err := c.notify.SendMeta(notifiarr.PlexHook, c.notify.URL, v, plex.WaitTime)
 	if err != nil {
 		c.Errorf("Sending Plex Session to Notifiarr: %v", err)
 		return
@@ -56,8 +56,6 @@ func (c *Client) collectSessions(v *plex.Webhook) {
 	} else {
 		c.Printf("Plex => Notifiarr: %s '%s' => %s", v.Account.Title, v.Event, v.Metadata.Title)
 	}
-
-	c.Debugf("Payload Sent: %s", strings.ReplaceAll(string(posted), "\n", " "))
 }
 
 // logSnaps writes a full snapshot payload to the log file.
@@ -83,7 +81,7 @@ func (c *Client) logSnaps() {
 	)
 
 	if c.Config.Plex != nil {
-		if plex, err = c.Config.Plex.GetSessions(); err != nil {
+		if plex, err = c.Config.Plex.GetXMLSessions(); err != nil {
 			c.Errorf("[user requested] %v", err)
 		}
 	}

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -155,7 +155,7 @@ func (c *Client) displayConfig() (s string) { //nolint: funlen,cyclop
 func (c *Client) sendPlexSessions(url string) {
 	c.Printf("[user requested] Sending Plex Sessions to %s", url)
 
-	if _, body, err := c.notify.SendMeta(notifiarr.PlexCron, url, nil, 0); err != nil {
+	if body, err := c.notify.SendMeta(notifiarr.PlexCron, url, nil, 0); err != nil {
 		c.Errorf("[user requested] Sending Plex Sessions to %s: %v: %v", url, err, string(body))
 	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
 		c.Printf("[user requested] Sent Plex Sessions to %s, reply: %s", url, fields[3])
@@ -182,8 +182,6 @@ func (c *Client) sendSystemSnapshot(url string) {
 	}
 
 	b, _ := json.MarshalIndent(&notifiarr.Payload{Type: notifiarr.SnapCron, Snap: snaps}, "", "  ")
-	c.Debugf("Sending payload:\n%s", string(b))
-
 	if body, err := c.notify.SendJSON(url, b); err != nil {
 		c.Errorf("[user requested] Sending System Snapshot to %s: %v: %s", url, err, string(body))
 	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd

--- a/pkg/notifiarr/plexcron.go
+++ b/pkg/notifiarr/plexcron.go
@@ -26,7 +26,7 @@ func (c *Config) startPlexCron() {
 	for {
 		select {
 		case <-t.C:
-			if _, body, err := c.SendMeta(PlexCron, c.URL, nil, 0); err != nil {
+			if body, err := c.SendMeta(PlexCron, c.URL, nil, 0); err != nil {
 				c.Errorf("Sending Plex Session to %s: %v: %v", c.URL, err, string(body))
 			} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
 				c.Printf("Plex Sessions sent to %s, sending again in %s, reply: %s", c.URL, c.Plex.Interval, fields[3])

--- a/pkg/notifiarr/snapcron.go
+++ b/pkg/notifiarr/snapcron.go
@@ -66,6 +66,7 @@ func (c *Config) sendSnapshot() {
 		}
 	}
 
+	// These debug messages are mostly just errors that we we expect to have.
 	for _, err := range debug {
 		if err != nil {
 			c.Debugf("Snapshot: %v", err)

--- a/pkg/plex/sessions.go
+++ b/pkg/plex/sessions.go
@@ -21,7 +21,7 @@ type Session interface{}
 
 var ErrBadStatus = fmt.Errorf("status code not 200")
 
-func (s *Server) GetSessions() (*Sessions, error) {
+func (s *Server) GetXMLSessions() (*Sessions, error) {
 	if s == nil || s.URL == "" || s.Token == "" {
 		return nil, ErrNoURLToken
 	}
@@ -59,6 +59,30 @@ func (s *Server) GetSessions() (*Sessions, error) {
 		XML:        string(xml),
 		Sessions:   v.MediaContainer.Sessions,
 	}, nil
+}
+
+func (s *Server) GetSessions() ([]*Session, error) {
+	if s == nil || s.URL == "" || s.Token == "" {
+		return nil, ErrNoURLToken
+	}
+
+	var v struct {
+		MediaContainer struct {
+			Size     int        `json:"size"`
+			Sessions []*Session `json:"Metadata"`
+		} `json:"MediaContainer"`
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
+	defer cancel()
+
+	if data, err := s.getPlexSessions(ctx, map[string]string{"Accept": "application/json"}); err != nil {
+		return nil, err
+	} else if err = json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("parsing plex sessions: %w", err)
+	}
+
+	return v.MediaContainer.Sessions, nil
 }
 
 func (s *Server) getPlexSessions(ctx context.Context, headers map[string]string) ([]byte, error) {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -262,8 +262,6 @@ func (c *Config) RunChecks(what string) *Results {
 // SendResults sends a set of Results to Notifiarr.
 func (c *Config) SendResults(results *Results, url string) {
 	data, _ := json.MarshalIndent(results, "", " ")
-	c.Debug("Sending Payload:", string(data))
-
 	if _, err := c.Notify.SendJSON(url, data); err != nil {
 		c.Error("Sending service check update to Notifiarr:", err)
 	}


### PR DESCRIPTION
This moves all the prints for debug payloads to 1 place. Adds a new GetSessions method too.